### PR TITLE
Add files via upload

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+    "rewrites": [
+      { "source": "/(.*)", "destination": "/index.html" }
+    ]
+  }
+  


### PR DESCRIPTION
 In SPAs, the navigation between different pages or routes is handled on the client-side using JavaScript. This means that when you click on a link within the app, JavaScript loads the necessary content without actually requesting a new page from the server.

However, sometimes when you reload or try to directly access a specific route (URL) in the SPA, the server doesn't recognize that route, and it shows a "404: NOT_FOUND" error because there's no corresponding file on the server for that route.

To fix this issue, we need to configure the server to redirect all requests to the main entry point of the SPA, which is usually the index.html file. This way, when a request comes in for any route, the server will always serve the index.html file, and then the client-side JavaScript will take over and handle the routing within the SPA.

In Vercel, we can set up this configuration using a file called vercel.json or now.json, depending on the Vercel version. Inside this file, we add a special rule called a "rewrite." The rewrite rule tells the server to redirect all requests, regardless of the route, to the index.html file. Here's what the rule looks like: